### PR TITLE
feat: remove instagram and whatsapp

### DIFF
--- a/lib/social-media.tsx
+++ b/lib/social-media.tsx
@@ -2,10 +2,8 @@
 import { SocialMediaProps } from '@ircsignpost/signpost-base/dist/src/header-banner';
 
 import facebookImage from '../public/facebook.svg';
-import instagramImage from '../public/instagram.svg';
 import messengerImage from '../public/messenger.svg';
 import telegramImage from '../public/telegram.svg';
-import whatsappImage from '../public/whatsapp.svg';
 
 export interface SocialMediaLink {
   title: string;
@@ -15,9 +13,7 @@ export interface SocialMediaLink {
 // Serializable social media links
 export interface SocialMediaLinks {
   facebookLink: SocialMediaLink;
-  whatsappLink: SocialMediaLink;
   messengerLink: SocialMediaLink;
-  instagramLink: SocialMediaLink;
   telegramLink: SocialMediaLink;
 }
 
@@ -32,18 +28,12 @@ export function getSocialMediaProps(
       ...socialMediaLinks.facebookLink,
       image: facebookImage,
     },
-    {
-      ...socialMediaLinks.whatsappLink,
-      image: whatsappImage,
-    },
+
     {
       ...socialMediaLinks.messengerLink,
       image: messengerImage,
     },
-    {
-      ...socialMediaLinks.instagramLink,
-      image: instagramImage,
-    },
+
     {
       ...socialMediaLinks.telegramLink,
       image: telegramImage,

--- a/lib/translations.tsx
+++ b/lib/translations.tsx
@@ -107,18 +107,12 @@ export function populateSocialMediaLinks(dynamicContent: {
       title: dynamicContent['default_banner_facebook_title'],
       href: dynamicContent['ri_czechia_facebook_link'],
     },
-    whatsappLink: {
-      title: dynamicContent['default_banner_whatsapp_title'],
-      href: dynamicContent['ri_czechia_whatsapp_link'],
-    },
+
     messengerLink: {
       title: dynamicContent['default_banner_messenger_title'],
       href: dynamicContent['ri_czechia_messenger_link'],
     },
-    instagramLink: {
-      title: dynamicContent['default_banner_instagram_title'],
-      href: dynamicContent['ri_czechia_instagram_link'],
-    },
+
     telegramLink: {
       title: dynamicContent['default_banner_telegram_title'],
       href: dynamicContent['ri_czechia_telegram_link'],


### PR DESCRIPTION
Social buttons updated - links added for Facebook, Telegram, Messenger

Instagram and whatsApp buttons removed.